### PR TITLE
Issue #7: Missing forward slash in generated TemplateURL

### DIFF
--- a/templates/wordpress-master.template
+++ b/templates/wordpress-master.template
@@ -556,7 +556,7 @@
             "Type": "AWS::CloudFormation::Stack",
             "Properties": {
                 "TemplateURL": {
-                    "Fn::Sub": "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template"
+                    "Fn::Sub": "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}/submodules/quickstart-aws-vpc/templates/aws-vpc.template"
                 },
                 "Parameters": {
                     "AvailabilityZones": {


### PR DESCRIPTION
Added in the `/` that was missing in the TemplateURL