### PR TITLE
Update taskcat scenarios

### DIFF
--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -16,7 +16,7 @@ global:
   reporting: true
 tests:
   bitnami-wordpress-ssl:
-    parameter_input: wordpress-master.json
+    parameter_input: wordpress-master-ssl.json
     template_file: wordpress-master.template
   bitnami-wordpress:
     parameter_input: wordpress-master.json

--- a/ci/wordpress-master-ssl.json
+++ b/ci/wordpress-master-ssl.json
@@ -52,6 +52,19 @@
         "ParameterValue": "10.0.0.0/16"
     },
     {
+        "ParameterKey": "DomainName",
+        "ParameterValue": "override.example.com"
+
+    },
+    {
+        "ParameterKey": "CertificateArn",
+        "ParameterValue": ""
+    },
+    {
+        "ParameterKey": "HostedZoneID",
+        "ParameterValue": "override"
+    },
+    {
         "ParameterKey": "VPCCIDR",
         "ParameterValue": "10.0.0.0/16"
     },

--- a/ci/wordpress-master.json
+++ b/ci/wordpress-master.json
@@ -52,19 +52,6 @@
         "ParameterValue": "10.0.0.0/16"
     },
     {
-        "ParameterKey": "DomainName",
-        "ParameterValue": "override.example.com"
-
-    },
-    {
-        "ParameterKey": "CertificateArn",
-        "ParameterValue": ""
-    },
-    {
-        "ParameterKey": "HostedZoneID",
-        "ParameterValue": "override"
-    },
-    {
         "ParameterKey": "VPCCIDR",
         "ParameterValue": "10.0.0.0/16"
     },


### PR DESCRIPTION
- Rename parameter files.
- Update `bitnami-wordpress-ssl` taskcat scenario.

Before this change both scenarios were testing the SSL case.

 ---

Once the test for **non** SSL scenario is executed, the creation of the stack fails because the dependency below can't be satisfied (the stack `ConfigureSSLStack` is not created).

https://github.com/aws-quickstart/quickstart-bitnami-wordpress/blob/0600fb889b229b92107d282ac85ea150b4d21a78/templates/wordpress-master.template#L707-L708

I have not found a way to solve it yet. Any ideas @agamzn?.