### PR TITLE
Fix SSL certs conditionals and DNS records

### DIFF
--- a/templates/acm-cert-r53-record.template
+++ b/templates/acm-cert-r53-record.template
@@ -281,7 +281,6 @@
     },
     "Outputs": {
         "ACMCertificate": {
-            "Condition": "SetupRoute53",
             "Description": "ARN of the ACM-Generated SSL Certificate",
             "Value": {
                 "Fn::If": [

--- a/templates/webserver.template
+++ b/templates/webserver.template
@@ -41,7 +41,8 @@
                     },
                     "Parameters": [
                         "DomainName",
-                        "CertificateArn"
+                        "CertificateArn",
+                        "HostedZoneID"
                     ]
                 },
                 {
@@ -329,6 +330,12 @@
             "Type": "String",
             "Default": ""
         },
+        "HostedZoneID": {
+            "Description": "(Optional) Route 53 Hosted Zone ID of the domain name. If left blank route 53 will not be configured and DNS must be setup manually. If you specify this, you must also specify a Domain name",
+            "Type": "String",
+            "Default": "",
+            "MaxLength": "32"
+        },
         "ElastiCacheEnable": {
             "Description": "Enable ElastiCache",
             "AllowedValues": [
@@ -443,13 +450,29 @@
             ]
         },
         "AddDNSRecord": {
-            "Fn::Not": [
+            "Fn::And": [
                 {
-                    "Fn::Equals": [
+                    "Fn::Not": [
                         {
-                            "Ref": "DomainName"
-                        },
-                        ""
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "DomainName"
+                                },
+                                ""
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "HostedZoneID"
+                                },
+                                ""
+                            ]
+                        }
                     ]
                 }
             ]
@@ -696,6 +719,33 @@
                         }
                     }
                 ]
+            }
+        },
+        "Route53RecordSet": {
+            "Condition": "AddDNSRecord",
+            "Type": "AWS::Route53::RecordSet",
+            "Properties": {
+                "Type": "A",
+                "Name": {
+                    "Ref": "DomainName"
+                },
+                "AliasTarget": {
+                    "HostedZoneId": {
+                        "Fn::GetAtt": [
+                            "ApplicationLoadBalancer",
+                            "CanonicalHostedZoneID"
+                        ]
+                    },
+                    "DNSName": {
+                        "Fn::GetAtt": [
+                            "ApplicationLoadBalancer",
+                            "DNSName"
+                        ]
+                    }
+                },
+                "HostedZoneId": {
+                    "Ref": "HostedZoneID"
+                }
             }
         },
         "WebServerASG": {

--- a/templates/wordpress-master.template
+++ b/templates/wordpress-master.template
@@ -676,9 +676,9 @@
             { "Fn::Not": [ { "Fn::Equals": [{ "Ref": "CertificateArn"}, "" ] } ] }
           ]
         },
-        "UserProvidedSSL":{
+        "GenerateSSLCertificate": {
           "Fn::And": [
-            { "Fn::Not": [{ "Fn::Equals": [{ "Ref": "CertificateArn"},""]}]},
+            { "Fn::Equals": [{ "Ref": "CertificateArn"},""]},
             { "Condition":"UseSSL" }
           ]
         }
@@ -770,6 +770,7 @@
         },
         "CopyLambdaStack": {
             "DependsOn":"VPCStack",
+            "Condition": "GenerateSSLCertificate",
             "Type":"AWS::CloudFormation::Stack",
             "Properties":{
                 "TemplateURL":{
@@ -786,8 +787,7 @@
             }
         },
         "ConfigureSSLStack": {
-            "DependsOn":"CopyLambdaStack",
-            "Condition":"UseSSL",
+            "Condition":"GenerateSSLCertificate",
             "Type":"AWS::CloudFormation::Stack",
             "Properties":{
                 "TemplateURL":{
@@ -905,15 +905,15 @@
                           "UseSSL",
                           {
                             "Fn::If": [
-                                "UserProvidedSSL",
-                                {
-                                  "Ref": "CertificateArn"
-                                },
+                                "GenerateSSLCertificate",
                                 {
                                   "Fn::GetAtt": [
                                       "ConfigureSSLStack",
                                       "Outputs.ACMCertificate"
                                   ]
+                                },
+                                {
+                                  "Ref": "CertificateArn"
                                 }
                             ]
                           },

--- a/templates/wordpress.template
+++ b/templates/wordpress.template
@@ -832,6 +832,9 @@
                     "CertificateArn": {
                         "Ref": "CertificateArn"
                     },
+                    "HostedZoneID": {
+                        "Ref": "HostedZoneID"
+                    },
                     "ElastiCacheEnable": {
                         "Ref": "ElastiCacheEnable"
                     },


### PR DESCRIPTION
*Description of changes:*

- Fix SSL certs conditionals. A certificate was generated even if the `CertificateArn` parameter was provided.
- Add DNS A record (alias) to the ELB endpoint in the HostedZone when possible.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
