### PR TITLE
Add the option to enable storage encryption for RDS

### DIFF
--- a/templates/rdsaurora.template
+++ b/templates/rdsaurora.template
@@ -35,6 +35,15 @@
             "Description": "(Optional) Preferred backup window",
             "Type": "String"
         },
+        "DBStorageEncrypted": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "false",
+            "Description": "Select true/false to enable storage encryption in the database instances",
+            "Type": "String"
+        },
         "DBInstanceClass": {
             "AllowedValues": [
                 "db.t2.micro",
@@ -111,6 +120,14 @@
                 },
                 "true"
             ]
+        },
+        "EnableStorageEncryption": {
+            "Fn::Equals": [
+                {
+                    "Ref": "DBStorageEncrypted"
+                },
+                "true"
+            ]
         }
     },
     "Resources": {
@@ -126,6 +143,15 @@
         "AuroraDBCluster": {
             "Type": "AWS::RDS::DBCluster",
             "Properties": {
+                "StorageEncrypted": {
+                    "Fn::If": [
+                        "EnableStorageEncryption",
+                        "true",
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
                 "BackupRetentionPeriod": {
                     "Ref": "DBBackupRetentionPeriod"
                 },

--- a/templates/wordpress-master.template
+++ b/templates/wordpress-master.template
@@ -37,6 +37,7 @@
                         "DBAutoMinorVersionUpgrade",
                         "DBBackupRetentionPeriod",
                         "DBPreferredBackupWindow",
+                        "DBStorageEncrypted",
                         "DBInstanceClass",
                         "DBMasterUserPassword",
                         "DBMultiAZ"
@@ -111,6 +112,9 @@
                 },
                 "DBPreferredBackupWindow": {
                     "default": "Preferred Backup Window"
+                },
+                "DBStorageEncrypted": {
+                    "default": "Enable Storage Encryption"
                 },
                 "DBInstanceClass": {
                     "default": "Database Instance Size"
@@ -271,6 +275,15 @@
             "ConstraintDescription": "Preferred backup window must be left blank or in the form of HH:MM-HH:MM",
             "Default": "",
             "Description": "(Optional) Preferred Backup Window, specified in the format HH:MM-HH:MM using UTC. Automated backups will occur within this time frame. When it's not set, the backup will take place during the default Backup Windows of the AWS region.",
+            "Type": "String"
+        },
+        "DBStorageEncrypted": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "false",
+            "Description": "Select true/false to enable storage encryption in the database instances.",
             "Type": "String"
         },
         "DBInstanceClass": {
@@ -1032,6 +1045,9 @@
                     },
                     "DBPreferredBackupWindow": {
                         "Ref": "DBPreferredBackupWindow"
+                    },
+                    "DBStorageEncrypted": {
+                        "Ref": "DBStorageEncrypted"
                     },
                     "WebServerInstanceType": {
                         "Ref": "WebServerInstanceType"

--- a/templates/wordpress.template
+++ b/templates/wordpress.template
@@ -27,6 +27,7 @@
                         "DBAutoMinorVersionUpgrade",
                         "DBBackupRetentionPeriod",
                         "DBPreferredBackupWindow",
+                        "DBStorageEncrypted",
                         "DBInstanceClass",
                         "DBMasterUserPassword",
                         "DBMultiAZ"
@@ -95,6 +96,9 @@
                 },
                 "DBPreferredBackupWindow": {
                     "default": "Preferred Backup Window"
+                },
+                "DBStorageEncrypted": {
+                    "default": "Enable Storage Encryption"
                 },
                 "DBInstanceClass": {
                     "default": "Database Instance Size"
@@ -216,6 +220,15 @@
             "ConstraintDescription": "Preferred backup window must be left blank or in the form of HH:MM-HH:MM",
             "Default": "",
             "Description": "(Optional) Preferred Backup Window, specified in the format HH:MM-HH:MM using UTC. Automated backups will occur within this time frame. When it's not set, the backup will take place during the default Backup Windows of the AWS region.",
+            "Type": "String"
+        },
+        "DBStorageEncrypted": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "false",
+            "Description": "Select true/false to enable storage encryption in the database instances.",
             "Type": "String"
         },
         "DBInstanceClass": {
@@ -780,6 +793,9 @@
                     },
                     "DBPreferredBackupWindow": {
                         "Ref": "DBPreferredBackupWindow"
+                    },
+                    "DBStorageEncrypted": {
+                        "Ref": "DBStorageEncrypted"
                     },
                     "DBInstanceClass": {
                         "Ref": "DBInstanceClass"


### PR DESCRIPTION
*Description of changes:*

This PR adds the option to enable storage encryption for RDS. The parameter is defaulting to "false" to avoid unexpected data loss on upgrades (updating the `StorageEncrypted` property requires replacement of the resources).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
