### PR TITLE
Allow "+ in AutoScalingNotificationEmail

### DIFF
--- a/templates/wordpress.template
+++ b/templates/wordpress.template
@@ -195,7 +195,7 @@
     },
     "Parameters": {
         "AutoScalingNotificationEmail": {
-            "AllowedPattern": "([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)",
+            "AllowedPattern": "([a-zA-Z0-9_\\-\\.\\+]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)",
             "ConstraintDescription": "Must be a valid email address.",
             "Description": "Email address to notify any scaling operation. When an Autoscaling event occurs, an email is sent to this mail address.",
             "Type": "String"


### PR DESCRIPTION
This email to use a + in the email address.

Example: test+wordpress@example.com


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
